### PR TITLE
fix: Configures CloudFormation linter to run only on *template.yaml files.

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Run Linter
         run: |
           cfn-lint --version
-          cfn-lint -t ./**/*.yaml -i W E3012 E3005
+          cfn-lint -t ./**/*template.yaml -i W E3012 E3005
       - name: Lint Code Base
         uses: github/super-linter@v4
         env:


### PR DESCRIPTION
## Cloud One Service
**select one or multiple if applicable**

[ ] **Common**

[ ] **Workload Security**

[ ] **Application Security**

[ ] **Network Security**

[ ] **File Storage Security**

[ ] **Container Security**

[ ] **Conformity**

[ ] **Open Source Security**

[X] **Other**


## Proposed Changes
  - Configures CloudFormation linter to run only on *template.yaml files.