### PR TITLE
bug(fix): fix package-lock.json syntax

### DIFF
--- a/Conformity/Integration/aws-cdk-conformity-to-s3/package-lock.json
+++ b/Conformity/Integration/aws-cdk-conformity-to-s3/package-lock.json
@@ -3734,7 +3734,6 @@
       "dev": true
     },
     "node_modules/decode-uri-component": {
-      dependabot/npm_and_yarn/Conformity/Integration/aws-cdk-conformity-to-s3/minimatch-and-aws-cdk/aws-iam-and-aws-cdk/aws-kms-and-aws-cdk/aws-lambda-and-aws-cdk/aws-lambda-event-sources-and-aws-cdk/aws-s3-and-aws-cdk/aws-sns-and-aws-cdk/aws-sqs-and-aws-cdk/core-and-aws-cdk/assert-3.1.2
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
       "integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==",


### PR DESCRIPTION
## Cloud One Service
**select one or multiple if applicable**

[ ] **Common**

[ ] **Workload Security**

[ ] **Application Security**

[ ] **Network Security**

[ ] **File Storage Security**

[ ] **Container Security**

[X] **Conformity**

[ ] **Open Source Security**


## Proposed Changes
  - Fix package-lock.json syntax