### PR TITLE
chore: Adding S3 Sync on PR to Hash folder

### DIFF
--- a/.github/workflows/of-pr.yaml
+++ b/.github/workflows/of-pr.yaml
@@ -1,0 +1,29 @@
+name: On Pull Request
+
+env:
+  BUCKET_NAME: 'cloudone-community'
+  AWS_REGION: 'us-east-1'
+
+on:
+  push:
+    branches:
+    - main
+  
+# Allows to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  sync-files:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - uses: jakejarvis/s3-sync-action@master
+      with:
+        args: --acl public-read --follow-symlinks --delete --exclude '.git/*'
+      env:
+        AWS_S3_BUCKET: ${{ env.BUCKET_NAME }}
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        AWS_REGION: ${{ env.AWS_REGION }}
+        DEST_DIR: latest
+        DEST_DIR: ${{ github.sha }}


### PR DESCRIPTION
## Cloud One Service
**select one or multiple if applicable**

[ ] **Common**

[ ] **Workload Security**

[ ] **Application Security**

[ ] **Network Security**

[ ] **File Storage Security**

[ ] **Container Security**

[ ] **Conformity**

[ ] **Open Source Security**

[x] **Other**


## Proposed Changes
  - Sybncs to S3 on a folder name after the commit hash.
  - This enables testing from bucket without main merge.