### PR TITLE
adding-some-flexibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@
 **/*.pub
 **/*.ppk
 **/id_rsa
+
+**/__pycache__

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+  "[python]": {
+    "editor.defaultFormatter": "ms-python.python"
+  },
+  "python.formatting.provider": "none"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,0 @@
-{
-  "[python]": {
-    "editor.defaultFormatter": "ms-python.python"
-  },
-  "python.formatting.provider": "none"
-}

--- a/Conformity/Integration/aws-cf-well-architected-review-tool/README.md
+++ b/Conformity/Integration/aws-cf-well-architected-review-tool/README.md
@@ -1,12 +1,12 @@
-# Well Architected Conformity Sync
+# Well-Architected Conformity Sync
 
-This tools sets up a synchronization link between Cloud One Conformity and a AWS Well Architected review.
+This tool sets up a one-way synchronization link between Cloud One Conformity and a AWS Well-Architected review of your choice.
 
-The sync is intended to assist answering the questions in a Well Architected review. It works by populating the 'Notes' field with a summary of Conformity findings. This summary can be used to determine whether a workload is applying the best practices effectively.
+The sync populates the 'Notes' field with a summary of Conformity findings. This summary helps determine whether a workload is applying the best practices effectively.
 
-The sync goes in one direction and works only by demand: from Conformity to the AWS Well Architected tool. If configurations are remediated you need to run the synchronization again **but keep in mind that existing notes will be over-written.**
+The sync works only by demand; if any configurations were remediated between runs you will need to run it again **but keep in mind that existing notes will be over-written.**
 
-For further detail, see the resources below:
+For further details, see the resources below:
 
 - See [AWS Well Architected Tool](https://cloudone.trendmicro.com/docs/conformity/aws-integration/#aws-well-architected-tool) for further details about Conformity's integration with the Well Architected tool.
 
@@ -18,8 +18,8 @@ For further detail, see the resources below:
 - AWS Account Id
 - Ensure the [workload has been defined](https://docs.aws.amazon.com/wellarchitected/latest/userguide/define-workload.html) in the AWS Well Architected tool
 - Have the following information available:
-  _ [**Cloud One Account Id**](https://cloudone.trendmicro.com/docs/cloud-account-management/aws/#cloud-account-page)
-  _ [**Cloud One Conformity External Id**](https://cloudone.trendmicro.com/docs/conformity/api-reference/tag/External-IDs)
+  - [**Cloud One Account Id**](https://cloudone.trendmicro.com/docs/cloud-account-management/aws/#cloud-account-page)
+  - [**Cloud One Conformity External Id**](https://cloudone.trendmicro.com/docs/conformity/api-reference/tag/External-IDs)
   - [**Cloud One API Key**](https://cloudone.trendmicro.com/docs/identity-and-account-management/c1-api-key/) with Full Access (Admin)
   - [**Cloud One Conformity AWS Account Id**](https://cloudone.trendmicro.com/docs/cloud-account-management/aws/#cloud-account-page)
 
@@ -36,9 +36,11 @@ There are two options for installing this integration:
 ### CLI Installation
 
 - Step 1: Run the `configure-stack.py` script with the appropriate values:
-  `configure-stack.py --workload WORKLOAD --accountId ACCOUNTID --region {trend-us-1,us-1,au-1,ie-1,sg-1,in-1,jp-1,ca-1,de-1} --apiKey APIKEY --conformityAccountId CONFORMITYACCOUNTID --externalId EXTERNALID --owner OWNER --environment ENVIRONMENT`
+  `configure-stack.py [-h] --accountId ACCOUNTID --region {trend-us-1,us-1,au-1,ie-1,sg-1,in-1,jp-1,ca-1,de-1} --apiKey APIKEY --conformityAccountId CONFORMITYACCOUNTID --externalId EXTERNALID --owner OWNER --environment ENVIRONMENT`
 - Step 2: Run the `sync.py` script with the appropriate values:
-  `sync.py --stackName STACKNAME`
+  `sync.py [-h] [--stackName STACKNAME] --workloadArn WORKLOADARN`
+
+Note: Step #2 is the 'sync'. Invoke it to update the well-architected review of your choice.
 
 ## Resources
 

--- a/Conformity/Integration/aws-cf-well-architected-review-tool/configure-stack.py
+++ b/Conformity/Integration/aws-cf-well-architected-review-tool/configure-stack.py
@@ -2,6 +2,7 @@
 
 import argparse
 import boto3
+import json
 
 parser = argparse.ArgumentParser(
     description='''
@@ -12,8 +13,6 @@ parser = argparse.ArgumentParser(
     Also assumes your AWS CLI is configured and that you have sufficient permissions
     to run 'aws cloudformation create-stack' with CAPABILITY_NAMED_IAM.'
     ''')
-parser.add_argument('--workload', type=str, required=True,
-                    help='Well Architected Workload Arn')
 parser.add_argument('--accountId', type=str, required=True,
                     help='Cloud One Account Id')
 parser.add_argument('--region', type=str, required=True, choices=[
@@ -39,11 +38,6 @@ with open('conformity-wellarchitected-sync.yaml', 'r') as reader:
                                Capabilities=[ 'CAPABILITY_NAMED_IAM' ],
                                Parameters=[
                                    {
-                                       'ParameterKey': 'Workload',
-                                       'ParameterValue': f'{args.workload}',
-                                       'UsePreviousValue': True
-                                   },
-                                   {
                                        'ParameterKey': 'CloudOneAccountId',
                                        'ParameterValue': f'{args.accountId}',
                                        'UsePreviousValue': True
@@ -59,14 +53,14 @@ with open('conformity-wellarchitected-sync.yaml', 'r') as reader:
                                        'UsePreviousValue': True
                                    },
                                    {
-                                       'ParameterKey': 'ExternalId',
-                                       'ParameterValue': f'{args.externalId}',
-                                       'UsePreviousValue': True
-                                   },
-                                   {
                                       'ParameterKey': 'ConformityAccountId',
                                       'ParameterValue': f'{args.conformityAccountId}',
                                       'UsePreviousValue': True
+                                   },
+                                   {
+                                       'ParameterKey': 'ExternalId',
+                                       'ParameterValue': f'{args.externalId}',
+                                       'UsePreviousValue': True
                                    },
                                    {
                                       'ParameterKey': 'Owner',
@@ -79,5 +73,4 @@ with open('conformity-wellarchitected-sync.yaml', 'r') as reader:
                                       'UsePreviousValue': True 
                                    }
                                ])
-
-print(response)
+print(json.dumps(response, indent=4))

--- a/Conformity/Integration/aws-cf-well-architected-review-tool/conformity-wellarchitected-sync.yaml
+++ b/Conformity/Integration/aws-cf-well-architected-review-tool/conformity-wellarchitected-sync.yaml
@@ -260,20 +260,22 @@ Resources:
           logger.info(f'Api Endpoint: {apiEndpoint}')
 
           header = {
-            'Content-Type': 'application/vnd.api+json',
-            'api-version': 'v1',
-            'Authorization': f'ApiKey {ApiKey}'
+            "Content-Type": "application/vnd.api+json",
+            "api-version": "v1",
+            "Authorization": f"ApiKey {ApiKey}"
           }
           logger.info(f'Header is: {header}')
 
           def lambda_handler(event, context):
             logger.info(f'Received payload: {event}')
+
+            response = None
             if 'workloadArn' not in event:
               response = {
-                'statusCode': 400,
-                'body': {
-                  'message': 'Missing parameter workloadArn',
-                  'input': event
+                "statusCode": 400,
+                "body": {
+                  "message": 'Missing parameter workloadArn',
+                  "input": event
                 }
               }
               logger.info(f'workloadArn parameter is missing. Returning an error: {response}')
@@ -281,9 +283,9 @@ Resources:
               workloadArn = event['workloadArn']
               arguments = {
                 'meta': {
-                  'accountId': f'{AccountId}',
-                  'roleArn': f'{RoleArn}',
-                  'workloadArn': f'{workloadArn}'
+                  "accountId": f'{AccountId}',
+                  "roleArn": f'{RoleArn}',
+                  "workloadArn": f'{workloadArn}'
                 }
               }
               encodedBody = json.dumps(arguments).encode('utf-8')
@@ -291,10 +293,17 @@ Resources:
 
               request = urllib.request.Request(url=apiEndpoint, data=encodedBody, headers=header, method='POST')
               logger.info(f'Querying the Cloud One Conformity API')
-              response = urllib.request.urlopen(request)
+              reply = urllib.request.urlopen(request)
 
-              decodedResponse = response.read().decode('utf-8')
+              decodedResponse = reply.read().decode('utf-8')
               logger.info(f'Response was: {decodedResponse}')
+              
+              response = {
+                "statusCode": 200,
+                "body": json.loads(decodedResponse)
+              }
+
+            return response
       TracingConfig:
         Mode: Active
       Tags:

--- a/Conformity/Integration/aws-cf-well-architected-review-tool/conformity-wellarchitected-sync.yaml
+++ b/Conformity/Integration/aws-cf-well-architected-review-tool/conformity-wellarchitected-sync.yaml
@@ -1,16 +1,12 @@
 AWSTemplateFormatVersion: 2010-09-09
-Description: Set up the API sync between Cloud One Conformity and the AWS Well Architected Tool
+Description: Set up the API sync between Cloud One Conformity and the AWS Well-Architected Tool
 Parameters:
-  Workload:
-    Type: String
-    Description: ARN of the Well-Architected Review to synchronize. See https://console.aws.amazon.com/wellarchitected/home for more details
-    NoEcho: true
   CloudOneAccountId:
     Type: String
-    Description: Cloud One Account Id of the AWS account containing the Well Architected Review to synchronize (can be obtained from Conformity Dashboard)
+    Description: Cloud One Account Id of the AWS account containing the Well-Architected review(s) to synchronize (can be obtained from Conformity Dashboard)
   CloudOneRegion:
     Type: String
-    Description: Cloud One Conformity service region, i.e same region as your Cloud One Account
+    Description: Cloud One service region
     Default: us-1
     AllowedValues:
       - us-1
@@ -42,9 +38,8 @@ Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:
       - Label:
-          default: "Well Architected Review"
+          default: "Well-Architected Review"
         Parameters:
-          - Workload
           - CloudOneAccountId
       - Label:
           default: "Cloud One Parameters"
@@ -59,28 +54,17 @@ Metadata:
           - Environment
           - Owner
     ParameterLabels:
-      Workload:
-        default: "Well Architected Workload Arn"
       CloudOneAccountId:
-        default: "Cloud One Account Id"
+        default: "Cloud One Account Id containing the Well-Architected Review"
       CloudOneRegion:
         default: "Cloud One Service Region"
       CloudOneAPIKey:
         default: "Cloud One API Key with Full Access rights"
       ConformityAccountId:
-        default: "Cloud One Conformity AWS Account Id"
+        default: "AWS Account Id of Cloud One Conformity"
       ExternalId:
         default: "Cloud One Conformity External Id"
 Resources:
-  WorkloadArn:
-    Type: AWS::SSM::Parameter
-    Properties:
-      Name: /TrendMicro/CloudOne/Conformity/wellarchitected-sync/WorkloadArn
-      DataType: text
-      Type: String
-      Description: ARN of the Well-Architected Review to synchronize. See https://console.aws.amazon.com/wellarchitected/home for more details
-      Value:
-        Ref: Workload
   C1CRegion:
     Type: AWS::SSM::Parameter
     Properties:
@@ -110,7 +94,7 @@ Resources:
     Type: AWS::IAM::ManagedPolicy
     Properties:
       ManagedPolicyName: C1ConformitySyncPolicy
-      Description: Allows updating the well-architected review
+      Description: Allows updating the answers in all well-architected reviews in this account
       Path: /
       PolicyDocument:
         Version: "2012-10-17"
@@ -119,8 +103,7 @@ Resources:
             Action:
               - "wellarchitected:GetAnswer"
               - "wellarchitected:UpdateAnswer"
-            Resource:
-              Ref: Workload
+            Resource: "*"
   C1ConformitySyncRole:
     Type: AWS::IAM::Role
     DependsOn:
@@ -144,8 +127,6 @@ Resources:
       ManagedPolicyArns:
         - Ref: C1ConformitySyncPolicy
       Tags:
-        - Key: "Name"
-          Value: "C1ConformitySyncRole"
         - Key: "Role"
           Value: "Allows Cloud One Conformity to update a Well Architected review"
         - Key: "Environment"
@@ -193,7 +174,7 @@ Resources:
         Statement:
           - Effect: Allow
             Action:
-              - "ssm:GetParameter"
+              - "ssm:GetParametersByPath"
             Resource:
               Fn::Join:
                 [
@@ -227,6 +208,15 @@ Resources:
         - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
         - Ref: C1ConformitySyncSecretsPolicy
         - Ref: C1ConformitySyncParametersPolicy
+      Tags:
+        - Key: "Role"
+          Value: "Allows Cloud One Conformity Sync Function to update a Well Architected review"
+        - Key: "Environment"
+          Value:
+            Ref: Environment
+        - Key: "Owner"
+          Value:
+            Ref: Owner
   C1ConformitySyncUpdateReview:
     Type: AWS::Lambda::Function
     DependsOn:
@@ -237,7 +227,9 @@ Resources:
       FunctionName: C1ConformitySyncUpdateReview
       Role:
         Fn::GetAtt: [C1ConformitySyncLambdaRole, Arn]
-      Runtime: python3.9
+      Runtime: python3.10
+      Architectures:
+        - arm64
       Handler: index.lambda_handler
       PackageType: Zip
       Timeout: 10
@@ -256,45 +248,58 @@ Resources:
           ApiKey = secretsClient.get_secret_value(SecretId=f'C1APIKey')['SecretString']
 
           parametersClient = boto3.client('ssm')
-          WorkloadArn = parametersClient.get_parameter(Name='/TrendMicro/CloudOne/Conformity/wellarchitected-sync/WorkloadArn')['Parameter']['Value']
-          AccountId = parametersClient.get_parameter(Name='/TrendMicro/CloudOne/Conformity/wellarchitected-sync/C1AccountId')['Parameter']['Value']
-          RoleArn = parametersClient.get_parameter(Name='/TrendMicro/CloudOne/Conformity/wellarchitected-sync/C1ConformitySyncRoleArn')['Parameter']['Value']
-          Region = parametersClient.get_parameter(Name='/TrendMicro/CloudOne/Conformity/wellarchitected-sync/C1CRegion')['Parameter']['Value']
+          parametersPath = f'/TrendMicro/CloudOne/Conformity/wellarchitected-sync'
+          parameters = parametersClient.get_parameters_by_path(Path=f'{parametersPath}/')
+
+          getParameter = lambda name : [ x for x in parameters['Parameters'] if x['Name'] == f'{parametersPath}/{name}' ][0]['Value']
+          AccountId = getParameter('C1AccountId')
+          RoleArn = getParameter('C1ConformitySyncRoleArn')
+          Region = getParameter('C1CRegion')
+
+          apiEndpoint = f'https://conformity.{Region}.cloudone.trendmicro.com/api/well-architected-tool/sync'
+          logger.info(f'Api Endpoint: {apiEndpoint}')
+
+          header = {
+            'Content-Type': 'application/vnd.api+json',
+            'api-version': 'v1',
+            'Authorization': f'ApiKey {ApiKey}'
+          }
+          logger.info(f'Header is: {header}')
 
           def lambda_handler(event, context):
-            
-            header = {
-              "Content-Type": "application/vnd.api+json",
-              "api-version": "v1",
-              "Authorization": f"ApiKey {ApiKey}"
-            }
-            logger.info(f'Header created: {header}')
-
-            arguments = {
-              "meta": {
-                "accountId": f'{AccountId}',
-                "roleArn": f'{RoleArn}',
-                "workloadArn": f'{WorkloadArn}'
+            logger.info(f'Received payload: {event}')
+            if 'workloadArn' not in event:
+              response = {
+                'statusCode': 400,
+                'body': {
+                  'message': 'Missing parameter workloadArn',
+                  'input': event
+                }
               }
-            }
-            encodedBody = json.dumps(arguments).encode('utf-8')
-            logger.info(f'Body created: {encodedBody}')
+              logger.info(f'workloadArn parameter is missing. Returning an error: {response}')
+            else:
+              workloadArn = event['workloadArn']
+              arguments = {
+                'meta': {
+                  'accountId': f'{AccountId}',
+                  'roleArn': f'{RoleArn}',
+                  'workloadArn': f'{workloadArn}'
+                }
+              }
+              encodedBody = json.dumps(arguments).encode('utf-8')
+              logger.info(f'Body created: {encodedBody}')
 
-            apiEndpoint = f'https://conformity.{Region}.cloudone.trendmicro.com/api/well-architected-tool/sync'
-            logger.info(f'Api Endpoint: {apiEndpoint}')
+              request = urllib.request.Request(url=apiEndpoint, data=encodedBody, headers=header, method='POST')
+              logger.info(f'Querying the Cloud One Conformity API')
+              response = urllib.request.urlopen(request)
 
-            request = urllib.request.Request(url=apiEndpoint, data=encodedBody, headers=header, method='POST')
-            response = urllib.request.urlopen(request)
-
-            decodedResponse = response.read().decode('utf-8')
-            logger.info(f'Response was: {decodedResponse}')
+              decodedResponse = response.read().decode('utf-8')
+              logger.info(f'Response was: {decodedResponse}')
       TracingConfig:
         Mode: Active
       Tags:
-        - Key: "Name"
-          Value: "C1ConformitySyncLambdaRole"
         - Key: "Role"
-          Value: "Updates the Well-Architected Review located at WorkloadArn"
+          Value: "Updates the Well-Architected Review indicated by the WorkloadArn parameter passed during invocation"
         - Key: "Environment"
           Value:
             Ref: Environment

--- a/Conformity/Integration/aws-cf-well-architected-review-tool/requirements.txt
+++ b/Conformity/Integration/aws-cf-well-architected-review-tool/requirements.txt
@@ -1,0 +1,10 @@
+boto3>=1.26.139
+botocore>=1.29.139
+cffi>=1.15.1
+docutils>=0.20.1
+jmespath>=1.0.1
+pycparser>=2.21
+python-dateutil>=2.8.2
+s3transfer>=0.6.1
+six>=1.16.0
+urllib3>=1.26.16

--- a/Conformity/Integration/aws-cf-well-architected-review-tool/sync.py
+++ b/Conformity/Integration/aws-cf-well-architected-review-tool/sync.py
@@ -3,25 +3,31 @@
 import argparse
 import json
 import boto3
+from botocore.response import StreamingBody
 
 parser = argparse.ArgumentParser(
-    description='''
+    description="""
     Syncs Conformity findings and the AWS Well-Architected Review using the infrastructure
     created by the stack conformity-wellarchitected-sync.yaml. 
     
     Assumes your AWS CLI is configured and that you have sufficient permissions
-    to invoke Lambda functions.'
-    ''')
-parser.add_argument('--stackName', type=str, default='Conformity-WellArchitectedReview-Sync',
-                    help='Name used to create the Conformity->Well Architected Review sync stack')
+    to invoke Lambda functions.
+
+    The function ARN can be found in the Outputs section of the stack.
+    """
+)
+parser.add_argument( "--stackName", type=str, default="Conformity-WellArchitectedReview-Sync", help="Name used to create the Conformity->Well-Architected Review sync stack")
+parser.add_argument("--workloadArn", type=str, required=True, help="Well-Architected Review to synchronize")
 args = parser.parse_args()
 
-cfnClient = boto3.client('cloudformation')
-stacks = cfnClient.describe_stacks(StackName=f'{args.stackName}')
-stack = stacks['Stacks'][0]
-outputs = stack['Outputs']
-lambdaFunctionArn = [ x['OutputValue'] for x in outputs if x['OutputKey'] == 'LambdaFunctionName' ][0]
+cfnClient = boto3.client("cloudformation")
+stacks = cfnClient.describe_stacks(StackName=f"{args.stackName}")
+stack = stacks["Stacks"][0]
+outputs = stack["Outputs"]
+lambdaFunctionArn = [ x["OutputValue"] for x in outputs if x["OutputKey"] == "LambdaFunctionName" ][0]
 
-lambdaClient = boto3.client('lambda')
-response = lambdaClient.invoke(FunctionName=f'{lambdaFunctionArn}', InvocationType='RequestResponse')
-print(response)
+lambdaClient = boto3.client("lambda")
+arguments = {"workloadArn": f"{args.workloadArn}"}
+response = lambdaClient.invoke( FunctionName=f"{lambdaFunctionArn}", InvocationType="RequestResponse", Payload=json.dumps(arguments).encode("utf-8"))
+apiResponse = json.loads(response['Payload'].read().decode('utf-8'))
+print(json.dumps(apiResponse, indent=4))


### PR DESCRIPTION
## Cloud One Service
**select one or multiple if applicable**

[ ] **Common**

[ ] **Workload Security**

[ ] **Application Security**

[ ] **Network Security**

[ ] **File Storage Security**

[ ] **Container Security**

[X] **Conformity**

[ ] **Open Source Security**

[ ] **Other**


## Proposed Changes
  Adds flexibility to aws-cf-well-architected-review-tool by allowing the user to specify the workloadArn during the sync step.